### PR TITLE
Add Data Access + Matching Helpers pages; supersede API stub

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -49,8 +49,10 @@ book:
     - reports.qmd
     - apps.qmd
     - maps.qmd
-    - api.qmd
     - db.qmd
+    - data-access.qmd
+    - helpers.qmd
+    - api.qmd
     - portals.qmd
     - status.qmd
     - refs.qmd

--- a/api.qmd
+++ b/api.qmd
@@ -1,33 +1,66 @@
 # API
 
-The raw interface to the Application Programming Interface (API) is available at:
+::: {.callout-important}
+## Superseded by direct querying + `calcofi4r` helpers
+
+The Postgres-backed Plumber API at [api.calcofi.io](https://api.calcofi.io) is
+**being phased out**. CalCOFI data is now published as versioned, public
+**Parquet** files that you query directly with DuckDB — no API server, no
+credentials, no rate limits.
+
+- To query the data directly (SQL, R, Python), see **[Data Access](data-access.qmd)**.
+- For biological ↔ environmental matching (the old `zooplankton_biomass`,
+  `itis_ichthyodata` and `ichthyodata` endpoints), see
+  **[Matching Helpers](helpers.qmd)** — the `calcofi4r` functions
+  `cc_match_zooplankton_biomass()`, `cc_match_ichthyo_by_taxon()` and
+  `cc_match_ichthyo_by_name()`.
+
+The endpoint notes below are retained as a historical reference and a map from
+each API endpoint to its replacement.
+:::
+
+The raw interface to the legacy Application Programming Interface (API) is
+available at:
 
 - [api.calcofi.io](https://api.calcofi.io)
 
-Here we will provide more guidance on how to use the API functions with documented input arguments, output results and examples of use. 
+## Endpoint → replacement
 
-## `/variables`: get list of variables for timeseries
+| Legacy endpoint | Replacement |
+|---|---|
+| `/variables` | `calcofi4r::cc_list_measurement_types()` |
+| `/timeseries` | direct SQL aggregation — see [Data Access](data-access.qmd) |
+| `/cruises` | `calcofi4r::cc_read_cruise()` |
+| `/raster` | direct SQL + `calcofi4r::pts_to_rast_idw()` |
+| `/cruise_lines`, `/cruise_line_profile` | direct SQL against `ctd_cast` / `ctd_thin` |
+| `zooplankton_biomass` | `calcofi4r::cc_match_zooplankton_biomass()` ([Matching Helpers](helpers.qmd)) |
+| `itis_ichthyodata` | `calcofi4r::cc_match_ichthyo_by_taxon()` ([Matching Helpers](helpers.qmd)) |
+| `ichthyodata` | `calcofi4r::cc_match_ichthyo_by_name()` ([Matching Helpers](helpers.qmd)) |
 
-Get list of variables for use in `/timeseries`
+## Legacy endpoint reference
 
-## `/species_groups`: get species groups for larvae
+### `/variables`: get list of variables for timeseries
 
-Not yet working. Get list of species groups for use with variables `larvae_counts.count` in `/timeseries`
+Get list of variables for use in `/timeseries`.
 
+### `/species_groups`: get species groups for larvae
 
-## `/timeseries`: get time series data
+Not yet working. Get list of species groups for use with variables `larvae_counts.count` in `/timeseries`.
 
-## `/cruises`: get list of cruises
+### `/timeseries`: get time series data
 
-Get list of cruises with summary stats as CSV table for time (`date_beg`)
+### `/cruises`: get list of cruises
 
-## `/raster`: get raster map of variable
+Get list of cruises with summary stats as CSV table for time (`date_beg`).
 
-Get raster of variable
+### `/raster`: get raster map of variable
 
-## `/cruise_lines`: get station lines from cruises
+Get raster of variable.
 
-Get station lines from cruises (with more than one cast)
+### `/cruise_lines`: get station lines from cruises
 
-## `/cruise_line_profile`
-Get profile at depths for given variable of casts along line of stations
+Get station lines from cruises (with more than one cast).
+
+### `/cruise_line_profile`
+
+Get profile at depths for given variable of casts along line of stations.

--- a/data-access.qmd
+++ b/data-access.qmd
@@ -1,0 +1,291 @@
+# Data Access
+
+CalCOFI [database](db.qmd) releases are published as **Parquet** files on a
+public Google Cloud Storage (GCS) bucket. You can query them directly with
+[DuckDB](https://duckdb.org) — from R, Python, the DuckDB CLI, or any DuckDB
+client — with **no credentials, no API server, and no full download**. DuckDB
+reads only the columns and row groups a query actually touches, straight over
+HTTPS.
+
+This page covers querying the release Parquet directly. For convenience-wrapped
+biological ↔ environmental matching, see [Matching Helpers](helpers.qmd).
+
+## Where the data lives
+
+Each release is a versioned folder:
+
+```
+gs://calcofi-db/ducklake/releases/{version}/
+├── catalog.json          # table list, row counts, "partitioned" flag
+├── relationships.json    # primary keys + foreign keys
+├── RELEASE_NOTES.md
+└── parquet/
+    ├── {table}.parquet                  # single-file tables
+    └── {table}/cruise_key=.../*.parquet # hive-partitioned tables
+```
+
+- Public HTTPS base:
+  `https://storage.googleapis.com/calcofi-db/ducklake/releases/{version}/parquet`
+- `{version}` is e.g. `v2026.05.14`; the current release pointer is at
+  [`releases/latest.txt`](https://storage.googleapis.com/calcofi-db/ducklake/releases/latest.txt)
+  and the table list at `releases/{version}/catalog.json`.
+- Most tables are **single-file** (`{table}.parquet`). The large CTD tables
+  `ctd_thin` and `ctd_summary` are **hive-partitioned** by `cruise_key`
+  (`catalog.json` flags these with `"partitioned": true`).
+
+## Setup: the `httpfs` extension
+
+DuckDB reads remote Parquet through its `httpfs` extension. Spatial queries
+(e.g. distances between casts and tows) also need `spatial`. Both are one-time
+installs, then loaded per session:
+
+```sql
+INSTALL httpfs; LOAD httpfs;
+INSTALL spatial; LOAD spatial;   -- only if you use ST_* functions
+```
+
+## Single-file tables
+
+A single-file table is just an HTTPS URL handed to `read_parquet()`:
+
+```sql
+SELECT species_id, scientific_name, common_name, worms_id
+FROM read_parquet('https://storage.googleapis.com/calcofi-db/ducklake/releases/v2026.05.14/parquet/species.parquet')
+WHERE scientific_name = 'Sardinops sagax';
+```
+
+Joins work the same way — name each table's URL. The biological hierarchy is
+`ichthyo` → `net` → `tow` → `site` (and `ichthyo` → `species`); the
+environmental hierarchy is `bottle_measurement` → `bottle` → `casts`:
+
+```sql
+SELECT i.ichthyo_uuid, i.life_stage, i.tally, sp.scientific_name, t.time_start
+FROM read_parquet('https://storage.googleapis.com/calcofi-db/ducklake/releases/v2026.05.14/parquet/ichthyo.parquet') i
+JOIN read_parquet('https://storage.googleapis.com/calcofi-db/ducklake/releases/v2026.05.14/parquet/species.parquet') sp ON i.species_id = sp.species_id
+JOIN read_parquet('https://storage.googleapis.com/calcofi-db/ducklake/releases/v2026.05.14/parquet/net.parquet')     n  ON i.net_uuid   = n.net_uuid
+JOIN read_parquet('https://storage.googleapis.com/calcofi-db/ducklake/releases/v2026.05.14/parquet/tow.parquet')     t  ON n.tow_uuid   = t.tow_uuid
+WHERE sp.scientific_name = 'Sardinops sagax'
+LIMIT 10;
+```
+
+## Hive-partitioned tables
+
+`ctd_thin` and `ctd_summary` are partitioned into one folder per `cruise_key`.
+Reading them needs an **s3-style glob** (plain HTTPS URLs can't glob), so
+configure DuckDB's anonymous s3 access — GCS is s3-compatible:
+
+```sql
+INSTALL httpfs; LOAD httpfs;
+SET s3_region            = 'auto';
+SET s3_endpoint          = 'storage.googleapis.com';
+SET s3_url_style         = 'path';
+SET s3_access_key_id     = '';
+SET s3_secret_access_key = '';
+
+SELECT cruise_key, count(*) AS n
+FROM read_parquet(
+  's3://calcofi-db/ducklake/releases/v2026.05.14/parquet/ctd_thin/**/*.parquet',
+  hive_partitioning = true)
+GROUP BY cruise_key
+ORDER BY cruise_key;
+```
+
+Because `cruise_key` is the partition column, filtering on it lets DuckDB
+**prune** whole partitions — a single-cruise query never opens the other ~96
+folders.
+
+## From R
+
+Use `DBI` + `duckdb` directly:
+
+```r
+library(DBI)
+con <- dbConnect(duckdb::duckdb())
+dbExecute(con, "INSTALL httpfs; LOAD httpfs;")
+
+base <- "https://storage.googleapis.com/calcofi-db/ducklake/releases/v2026.05.14/parquet"
+d <- dbGetQuery(con, sprintf(
+  "SELECT scientific_name, common_name, worms_id
+   FROM read_parquet('%s/species.parquet')
+   WHERE common_name ILIKE '%%sardine%%'", base))
+```
+
+Or let the [`calcofi4r`](https://calcofi.io/calcofi4r) package register every
+release table as a view for you — it handles `httpfs`, the partitioned tables,
+and local caching:
+
+```r
+# remotes::install_github("calcofi/calcofi4r")
+library(calcofi4r)
+
+con <- cc_get_db()                       # latest release, tables as views
+DBI::dbListTables(con)
+
+# lazy dbplyr against the remote parquet
+library(dplyr)
+tbl(con, "species") |> filter(scientific_name == "Sardinops sagax")
+
+# or a one-off SQL query
+cc_query("SELECT count(*) FROM ichthyo")
+```
+
+## From Python
+
+```python
+import duckdb
+
+con = duckdb.connect()
+con.sql("INSTALL httpfs; LOAD httpfs;")
+
+base = "https://storage.googleapis.com/calcofi-db/ducklake/releases/v2026.05.14/parquet"
+df = con.sql(f"""
+  SELECT scientific_name, common_name, worms_id
+  FROM read_parquet('{base}/species.parquet')
+  WHERE common_name ILIKE '%sardine%'
+""").df()
+```
+
+## Reproducibility
+
+Because every query is plain SQL against immutable, versioned, public Parquet,
+a CalCOFI result is **reproducible by anyone** — pin the `{version}` and re-run
+the SQL.
+
+The [Integrated App](https://app.calcofi.io/int) builds on this: its data
+**download bundle** ships a `query/` folder alongside the data:
+
+```
+data/original/{bio,env}.csv          ← query/{bio,env}.sql
+data/integrated/integrated_*.csv     ← query/integrated_*.sql
+query/manifest.json                  release version, filters, GCS source URLs,
+                                     per-file row counts + md5 checksums
+query/REPRODUCE.md                   DuckDB-CLI / Python / R re-run snippets
+```
+
+Each `*.sql` file is fully interpolated, GCS-URL-based, and copy-paste runnable
+(prefixed with the `INSTALL`/`LOAD` it needs). Re-run `query/integrated_*.sql`
+in DuckDB and you get back exactly the rows in the matching `.csv` — the
+`manifest.json` md5 checksums let you confirm it. The same SQL is what
+[`calcofi4r::cc_match_bio_env()`](helpers.qmd) executes and attaches as
+`attr(x, "sql")`, so the app, the package, and a hand-written query are all the
+**same single source of truth**.
+
+## Worked example: sardine larvae + temperature {#sec-worked-example}
+
+The recurring example through these pages is *Pacific sardine
+(`Sardinops sagax`) larvae matched to CTD-bottle temperature, Q1 2018, with
+relaxed (5 km / 72 hr) matching*.
+
+::: {.callout-note}
+Q1 **2018** — not a more recent year — because CTD-bottle environmental data in
+the current release ends 2021-05, while net-tow biological data runs later. Q1
+2018 has ample overlap of both.
+:::
+
+Done as **direct SQL**, the query is a temporal interval join plus a spatial
+`ST_Distance_Sphere` filter. After the `INSTALL`/`LOAD` setup above, run the
+query below. This block is character-for-character what
+[`calcofi4r::cc_match_ichthyo_by_name()`](helpers.qmd) returns as
+`attr(d, "sql")` — the two produce the **identical 13 rows**. The
+[Integrated App](https://app.calcofi.io/int) download bundle builds
+`query/integrated_*.sql` with the same `cc_match_bio_env()` engine (its
+filter set is taxa + quarters + dates rather than `life_stage`, so a
+sardine / Q1 2018 bundle returns the egg + larva superset — same matching
+mechanics, same reproducibility):
+
+```sql
+WITH bio AS (
+SELECT
+  i.ichthyo_uuid::VARCHAR AS bio_id,
+  t.time_start            AS bio_datetime,
+  s.longitude             AS bio_lon,
+  s.latitude              AS bio_lat,
+  n.std_haul_factor * i.tally / nullif(n.prop_sorted, 0) AS bio_value,
+  sp.scientific_name,
+  sp.common_name,
+  sp.worms_id,
+  i.life_stage,
+  i.tally
+FROM read_parquet('https://storage.googleapis.com/calcofi-db/ducklake/releases/v2026.05.14/parquet/ichthyo.parquet') i
+JOIN read_parquet('https://storage.googleapis.com/calcofi-db/ducklake/releases/v2026.05.14/parquet/species.parquet') sp ON i.species_id = sp.species_id
+JOIN read_parquet('https://storage.googleapis.com/calcofi-db/ducklake/releases/v2026.05.14/parquet/net.parquet')     n  ON i.net_uuid   = n.net_uuid
+JOIN read_parquet('https://storage.googleapis.com/calcofi-db/ducklake/releases/v2026.05.14/parquet/tow.parquet')     t  ON n.tow_uuid   = t.tow_uuid
+JOIN read_parquet('https://storage.googleapis.com/calcofi-db/ducklake/releases/v2026.05.14/parquet/site.parquet')    s  ON t.site_uuid  = s.site_uuid
+WHERE i.tally IS NOT NULL
+    AND i.measurement_type IS NULL
+    AND t.time_start IS NOT NULL
+    AND s.longitude IS NOT NULL
+    AND s.latitude IS NOT NULL
+    AND sp.scientific_name IN ('Sardinops sagax')
+    AND i.life_stage IN ('larva')
+    AND t.time_start >= TIMESTAMP '2018-01-01'
+    AND t.time_start <= TIMESTAMP '2018-03-31'
+),
+env AS (
+SELECT
+  bm.bottle_measurement_id AS env_id,
+  c.datetime_utc           AS env_datetime,
+  c.lon_dec                AS env_lon,
+  c.lat_dec                AS env_lat,
+  bm.measurement_value     AS env_value,
+  b.depth_m                AS env_depth_m,
+  bm.measurement_type      AS measurement_type
+FROM read_parquet('https://storage.googleapis.com/calcofi-db/ducklake/releases/v2026.05.14/parquet/bottle_measurement.parquet') bm
+JOIN read_parquet('https://storage.googleapis.com/calcofi-db/ducklake/releases/v2026.05.14/parquet/bottle.parquet') b ON bm.bottle_id = b.bottle_id
+JOIN read_parquet('https://storage.googleapis.com/calcofi-db/ducklake/releases/v2026.05.14/parquet/casts.parquet')  c ON b.cast_id    = c.cast_id
+WHERE bm.measurement_type = 'temperature'
+    AND bm.measurement_value IS NOT NULL
+    AND c.datetime_utc IS NOT NULL
+    AND c.lon_dec IS NOT NULL
+    AND c.lat_dec IS NOT NULL
+    AND c.datetime_utc >= TIMESTAMP '2018-01-01' - INTERVAL '72 hours'
+    AND c.datetime_utc <= TIMESTAMP '2018-03-31' + INTERVAL '72 hours'
+),
+matched AS (
+  -- temporal interval join: every env observation within ± max_time_hr
+  SELECT
+    bio.*,
+    env.* EXCLUDE (env_lon, env_lat),
+    abs(epoch(bio.bio_datetime) - epoch(env.env_datetime)) / 3600.0 AS time_diff_hr,
+    ST_Distance_Sphere(
+      ST_Point(bio.bio_lon, bio.bio_lat),
+      ST_Point(env.env_lon, env.env_lat)) / 1000.0                  AS dist_km
+  FROM bio
+  JOIN env
+    ON env.env_datetime BETWEEN bio.bio_datetime - INTERVAL '72 hours'
+                            AND bio.bio_datetime + INTERVAL '72 hours'
+),
+within AS (
+  -- spatial filter: keep pairs within max_dist_km
+  SELECT * FROM matched
+  WHERE dist_km <= 5
+),
+ranked AS (
+  SELECT
+    *,
+    min(time_diff_hr) OVER (PARTITION BY bio_id) AS mn_time_diff_hr,
+    min(dist_km)      OVER (PARTITION BY bio_id) AS mn_dist_km
+  FROM within
+)
+-- one row per bio observation (× measurement_type): env values aggregated
+SELECT
+  * EXCLUDE (
+    env_id, env_value, env_datetime, env_depth_m,
+    time_diff_hr, dist_km, mn_time_diff_hr, mn_dist_km),
+  count(*)                                            AS n_env,
+  avg(env_value)                                      AS env_value,
+  CASE WHEN count(*) = 1 THEN 0
+       ELSE coalesce(stddev_samp(env_value), 0) END   AS env_value_sd,
+  avg(env_depth_m)                                    AS env_depth_m,
+  min(env_datetime)                                   AS env_datetime_min,
+  max(env_datetime)                                   AS env_datetime_max,
+  avg(dist_km)                                        AS dist_km,
+  avg(time_diff_hr)                                   AS time_diff_hr
+FROM ranked
+WHERE time_diff_hr = mn_time_diff_hr
+GROUP BY ALL
+ORDER BY bio_id
+```
+
+The next page, [Matching Helpers](helpers.qmd), shows this same query as a
+one-liner.

--- a/helpers.qmd
+++ b/helpers.qmd
@@ -1,0 +1,170 @@
+# Matching Helpers
+
+The [`calcofi4r`](https://calcofi.io/calcofi4r) package provides helper
+functions that relate **biological** observations (net-tow ichthyoplankton or
+zooplankton biomass) to **environmental** observations (CTD-bottle
+measurements) by matching them in time and space — on the fly, against the
+public release [Parquet on GCS](data-access.qmd).
+
+These supersede the retired Postgres Plumber [API](api.qmd) endpoints
+`zooplankton_biomass`, `itis_ichthyodata` and `ichthyodata`, which depended on
+pre-built `uunet2ctd*` match tables that are no longer part of releases.
+
+## Install
+
+```r
+# remotes::install_github("calcofi/calcofi4r")
+library(calcofi4r)
+```
+
+The matching helpers need `calcofi4r` ≥ 1.2.0 and DuckDB with the `httpfs` and
+`spatial` extensions (the functions install/load these for you).
+
+## The wrappers
+
+Three wrappers cover the common cases. Each builds the matching SQL, runs it,
+and returns a tibble of **one row per biological observation** with the matched
+environmental value:
+
+| Function | Biological side | Replaces |
+|---|---|---|
+| `cc_match_ichthyo_by_name()` | ichthyoplankton, filtered by scientific name | `/ichthyodata` |
+| `cc_match_ichthyo_by_taxon()` | ichthyoplankton, filtered by a WoRMS taxon **and all its descendants** | `/itis_ichthyodata` |
+| `cc_match_zooplankton_biomass()` | net-tow displacement-volume biomass (`totalplankton` / `smallplankton`) | `/zooplankton_biomass` |
+
+```r
+# ichthyoplankton by scientific name
+d <- cc_match_ichthyo_by_name(
+  "Sardinops sagax", env_var = "temperature")
+
+# every descendant of a WoRMS taxon (recursive parentNameUsageID walk)
+d <- cc_match_ichthyo_by_taxon(
+  worms_id = 125724, env_var = "salinity")   # 125724 = genus Engraulis
+
+# zooplankton biomass
+d <- cc_match_zooplankton_biomass(
+  env_var = "temperature", biomass_type = "totalplankton")
+```
+
+## Worked example: sardine larvae + temperature
+
+The recurring example through these pages — *Pacific sardine
+(`Sardinops sagax`) larvae matched to CTD-bottle temperature, Q1 2018, with
+relaxed (5 km / 72 hr) matching* — is a single call:
+
+```r
+d <- cc_match_ichthyo_by_name(
+  "Sardinops sagax",
+  env_var        = "temperature",
+  life_stage     = "larva",
+  date_min       = "2018-01-01",
+  date_max       = "2018-03-31",
+  relax_matching = TRUE)
+```
+
+```r
+d[, c("scientific_name", "life_stage", "bio_datetime",
+      "bio_value", "n_env", "env_value", "dist_km", "time_diff_hr")]
+#> # A tibble: 13 × 8
+#>   scientific_name life_stage bio_datetime        bio_value n_env env_value dist_km time_diff_hr
+#>   <chr>           <chr>      <dttm>                  <dbl> <dbl>     <dbl>   <dbl>        <dbl>
+#> 1 Sardinops sagax larva      2018-02-05 00:44:00     116.     34      11.4   0.167         1.39
+#> 2 Sardinops sagax larva      2018-02-05 06:03:00      17.8    30      10.5   0.225         1.21
+#> 3 Sardinops sagax larva      2018-02-07 09:56:00     120.     33      10.4   …             …
+#> # … 10 more rows
+```
+
+`bio_value` is the standardized larval tally; `env_value` is the matched mean
+temperature (°C); `n_env` is how many bottle measurements were averaged;
+`dist_km` / `time_diff_hr` are the realized match offsets (within the 5 km /
+72 hr window). This returns the **identical 13 rows** as the [direct
+SQL](data-access.qmd#sec-worked-example) — `attr(d, "sql")` is that exact query.
+The [Integrated App](https://app.calcofi.io/int) download bundle uses the same
+`cc_match_bio_env()` engine for its `query/` folder.
+
+::: {.callout-note}
+Q1 **2018**, not a more recent year: CTD-bottle environmental data in the
+current release ends 2021-05, while net-tow biological data runs later. Q1 2018
+has ample overlap.
+:::
+
+## Reproducible SQL
+
+Every helper attaches the **exact, portable SQL** that produced the result, plus
+query metadata, as attributes:
+
+```r
+cat(attr(d, "sql"))           # the fully-interpolated, GCS-URL-based query
+str(attr(d, "query_meta"))    # package + release version, params, source URLs
+```
+
+`attr(d, "sql")` is character-for-character the query shown on the
+[Data Access](data-access.qmd#sec-worked-example) page — copy-paste it into the
+DuckDB CLI, Python, or a colleague's R session and it returns identical rows.
+That is the contract behind the [Integrated App](https://app.calcofi.io/int)
+download bundle's `query/` folder.
+
+To get the SQL **without running it** — e.g. to serialize or inspect it — pass
+`return_sql = TRUE`:
+
+```r
+sql <- cc_match_ichthyo_by_name("Sardinops sagax", return_sql = TRUE)
+cat(sql)
+```
+
+## The core engine: `cc_match_bio_env()`
+
+The wrappers are thin shells over `cc_match_bio_env()`, which takes a `bio` and
+an `env` SQL `SELECT` string and performs the match. Call it directly when you
+need a biological or environmental side the wrappers don't cover (custom
+filters, a different grouping, joining `bottle` to `cast_condition`, …):
+
+```r
+cc_match_bio_env(
+  bio, env,                                  # SELECT strings (see contract below)
+  max_dist_km = 2, max_time_hr = 6,          # match tolerances
+  join_method = "nearest_time",              # or "nearest_dist", "average"
+  version     = "latest",
+  collect     = TRUE,                        # FALSE → lazy dplyr::tbl
+  return_sql  = FALSE)                       # TRUE  → just the SQL string
+```
+
+**Contract.** `bio` must yield `bio_id`, `bio_datetime`, `bio_lon`, `bio_lat`,
+`bio_value` (plus any descriptive columns, carried through as grouping keys).
+`env` must yield exactly `env_id`, `env_datetime`, `env_lon`, `env_lat`,
+`env_value`, `env_depth_m`, `measurement_type`. Both typically `FROM
+read_parquet('https://…/{table}.parquet')` so the emitted SQL stays portable.
+
+## Parameters
+
+- **`max_dist_km`, `max_time_hr`** — the spatial and temporal match windows.
+  Defaults are 2 km / 6 hr; `relax_matching = TRUE` widens them to 5 km / 72 hr
+  (an explicit value always wins). This replaces the old API's `relax_matching`
+  boolean.
+- **`join_method`** — how the environmental observations inside the window are
+  reduced to one value per biological observation:
+  - `"nearest_time"` (default) — keep the closest in time, average ties;
+  - `"nearest_dist"` — keep the closest in space, average ties;
+  - `"average"` — average every observation in the window.
+
+  CalCOFI co-locates net tows and CTD casts, so in practice `nearest_time` and
+  `nearest_dist` usually agree and `average` differs only slightly.
+- **`life_stage`** (ichthyo wrappers) — restrict to e.g. `"larva"` or `"egg"`.
+- **`date_min`, `date_max`** — bound the biological side by tow start date.
+- **`depth_m_min`, `depth_m_max`** — bound the environmental bottle depths.
+- **`version`** — a release string like `"v2026.05.14"`, or `"latest"`.
+
+## Migrating from the API
+
+| Old API | New helper |
+|---|---|
+| `/ichthyodata` (`species`, `exact_match`) | `cc_match_ichthyo_by_name(scientific_name, exact_match=)` |
+| `/itis_ichthyodata` (`ITISid`) | `cc_match_ichthyo_by_taxon(worms_id)` — WoRMS, recursive subtree |
+| `/zooplankton_biomass` | `cc_match_zooplankton_biomass()` |
+| `relax_matching = TRUE` | `relax_matching = TRUE` (5 km / 72 hr) or explicit `max_dist_km` / `max_time_hr` |
+| `cruiseymd_min` / `cruiseymd_max` | `date_min` / `date_max` |
+| `stage` | `life_stage` |
+
+The taxon wrapper is the one real change: ITIS `path`-regex matching is gone;
+descendants are now resolved by a recursive walk of WoRMS
+`taxon.parentNameUsageID` against the release `taxon` table.


### PR DESCRIPTION
New data-access.qmd: querying frozen-release Parquet directly with DuckDB over GCS — httpfs setup, single-file vs hive-partitioned read_parquet, R / Python / calcofi4r entry points, a Reproducibility section on the Integrated App download query/ folder, and the worked example as direct SQL.

New helpers.qmd: the calcofi4r bio↔env matching helpers (cc_match_bio_env + cc_match_ichthyo_by_name / _by_taxon / zooplankton_biomass), the portable attr(x,"sql") contract, parameters, and an old-API → helper migration table.

api.qmd: a "superseded by direct querying + calcofi4r helpers" callout and an endpoint → replacement table; legacy endpoint notes retained for reference.

_quarto.yml: chapter order db → data-access → helpers → api.

Recurring worked example "Pacific sardine larvae + temperature, Q1 2018, relaxed matching" shown two ways with character-identical SQL (direct SQL == attr(cc_match_ichthyo_by_name(...),"sql"), both 13 rows); the Integrated App download is the third way. Q1 2018 not 2023: CTD-bottle env data ends 2021-05. All three pages render clean to HTML.

Part 6 of CTD-thinning epic. Refs CalCOFI/docs#5