### PR TITLE
Add docs/match/ DuckDB-WASM app; align "Run it from anywhere" across docs

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -3,6 +3,7 @@ project:
   output-dir: _book
   resources:
   - "/.nojekyll"
+  - "match/"   # standalone DuckDB-WASM Match app (see chapters: data-access, helpers, api)
   # pre-render:
   #   - libs/pre-render.R
   post-render:

--- a/api.qmd
+++ b/api.qmd
@@ -19,6 +19,17 @@ The endpoint notes below are retained as a historical reference and a map from
 each API endpoint to its replacement.
 :::
 
+::: {.callout-tip}
+## Try the new client-side Match app
+
+The three retired bio↔env endpoints are now an interactive form at
+**[/docs/match/](match/)** that runs entirely in your browser. Pick a function,
+fill the form, click **Run**, see the rows — no server, no credentials, no
+install. DuckDB-WASM in a worker thread, public Parquet on Google Cloud
+Storage, the same portable SQL the
+[`calcofi4r::cc_match_*()`](helpers.qmd) helpers emit.
+:::
+
 The raw interface to the legacy Application Programming Interface (API) is
 available at:
 
@@ -26,16 +37,16 @@ available at:
 
 ## Endpoint → replacement
 
-| Legacy endpoint | Replacement |
-|---|---|
-| `/variables` | `calcofi4r::cc_list_measurement_types()` |
-| `/timeseries` | direct SQL aggregation — see [Data Access](data-access.qmd) |
-| `/cruises` | `calcofi4r::cc_read_cruise()` |
-| `/raster` | direct SQL + `calcofi4r::pts_to_rast_idw()` |
-| `/cruise_lines`, `/cruise_line_profile` | direct SQL against `ctd_cast` / `ctd_thin` |
-| `zooplankton_biomass` | `calcofi4r::cc_match_zooplankton_biomass()` ([Matching Helpers](helpers.qmd)) |
-| `itis_ichthyodata` | `calcofi4r::cc_match_ichthyo_by_taxon()` ([Matching Helpers](helpers.qmd)) |
-| `ichthyodata` | `calcofi4r::cc_match_ichthyo_by_name()` ([Matching Helpers](helpers.qmd)) |
+| Legacy endpoint | R helper (`calcofi4r`) | Browser |
+|---|---|---|
+| `/variables` | `cc_list_measurement_types()` | — |
+| `/timeseries` | direct SQL aggregation — see [Data Access](data-access.qmd) | [SQL shell](match/#tab=shell) |
+| `/cruises` | `cc_read_cruise()` | — |
+| `/raster` | direct SQL + `pts_to_rast_idw()` | — |
+| `/cruise_lines`, `/cruise_line_profile` | direct SQL against `ctd_cast` / `ctd_thin` | [SQL shell](match/#tab=shell) |
+| `zooplankton_biomass` | [`cc_match_zooplankton_biomass()`](helpers.qmd) | **[Match → zoo biomass](match/)** |
+| `itis_ichthyodata` | [`cc_match_ichthyo_by_taxon()`](helpers.qmd) | **[Match → by taxon](match/)** |
+| `ichthyodata` | [`cc_match_ichthyo_by_name()`](helpers.qmd) | **[Match → by name](match/)** |
 
 ## Legacy endpoint reference
 

--- a/data-access.qmd
+++ b/data-access.qmd
@@ -145,6 +145,62 @@ df = con.sql(f"""
 """).df()
 ```
 
+## From your browser
+
+DuckDB compiles to WebAssembly, so the *same engine* runs **client-side in your
+browser** — no server, no install, no R or Python. CalCOFI ships a ready-made
+form at **[/docs/match/](match/)** wrapping the three retired bio↔env Plumber
+endpoints (and a free-form SQL shell); pick a function, fill the form, click
+**Run**, and a Chromium / Firefox / Safari worker thread fetches Parquet
+range-by-range over HTTPS and joins them in-browser:
+
+[![CalCOFI Match — DuckDB-WASM in your browser](https://img.shields.io/badge/Open-CalCOFI%20Match-2780e3?style=for-the-badge)](match/)
+
+To embed DuckDB-WASM in your own page, the boilerplate is about 15 lines —
+load the bundle from a CDN, instantiate, `INSTALL httpfs` and you're ready:
+
+```html
+<script type="module">
+  import * as duckdb from "https://cdn.jsdelivr.net/npm/@duckdb/duckdb-wasm@1.29.0/+esm";
+
+  const bundles = duckdb.getJsDelivrBundles();
+  const bundle  = await duckdb.selectBundle(bundles);
+  const worker  = await duckdb.createWorker(bundle.mainWorker);
+  const db      = new duckdb.AsyncDuckDB(new duckdb.ConsoleLogger(), worker);
+  await db.instantiate(bundle.mainModule, bundle.pthreadWorker);
+  const conn = await db.connect();
+  await conn.query("INSTALL httpfs; LOAD httpfs;");
+  await conn.query("INSTALL spatial; LOAD spatial;");
+
+  const base = "https://storage.googleapis.com/calcofi-db/ducklake/releases/v2026.05.14/parquet";
+  const result = await conn.query(`
+    SELECT scientific_name, common_name, worms_id
+    FROM read_parquet('${base}/species.parquet')
+    WHERE common_name ILIKE '%sardine%'
+  `);
+  console.log(result.toArray());
+</script>
+```
+
+For arbitrary one-off SQL with no setup at all, paste a query into
+[**shell.duckdb.org**](https://shell.duckdb.org) — DuckDB's official
+DuckDB-WASM shell. Same WebAssembly engine, same public Parquet, identical
+rows.
+
+## Run it from anywhere
+
+The same portable SQL — what [`calcofi4r::cc_match_*()`](helpers.qmd) emits as
+`attr(d, "sql")`, what the [Integrated App](https://app.calcofi.io/int)
+download bundle ships in its `query/` folder, what is shown in
+[the worked example](#sec-worked-example) below — runs in any DuckDB client:
+
+| Where | How |
+|---|---|
+| **R**, on your laptop | [`calcofi4r::cc_match_ichthyo_by_name(...)`](helpers.qmd) — emits and runs the SQL; `attr(d, "sql")` hands it back |
+| **Python**, on a notebook server | `duckdb.connect().sql(open("query.sql").read()).df()` — see [From Python](#from-python) |
+| **shell**, on the command line | `duckdb < query.sql` |
+| **your web browser**, no install | **[CalCOFI Match](match/)** — point-and-click form, runs DuckDB-WASM client-side |
+
 ## Reproducibility
 
 Because every query is plain SQL against immutable, versioned, public Parquet,
@@ -167,8 +223,9 @@ Each `*.sql` file is fully interpolated, GCS-URL-based, and copy-paste runnable
 in DuckDB and you get back exactly the rows in the matching `.csv` — the
 `manifest.json` md5 checksums let you confirm it. The same SQL is what
 [`calcofi4r::cc_match_bio_env()`](helpers.qmd) executes and attaches as
-`attr(x, "sql")`, so the app, the package, and a hand-written query are all the
-**same single source of truth**.
+`attr(x, "sql")`, what the browser-based **[Match app](match/)** generates as
+its `SQL` panel, and what a hand-written query produces — **a single source of
+truth across R, Python, the CLI and JavaScript**.
 
 ## Worked example: sardine larvae + temperature {#sec-worked-example}
 

--- a/helpers.qmd
+++ b/helpers.qmd
@@ -100,9 +100,10 @@ str(attr(d, "query_meta"))    # package + release version, params, source URLs
 
 `attr(d, "sql")` is character-for-character the query shown on the
 [Data Access](data-access.qmd#sec-worked-example) page — copy-paste it into the
-DuckDB CLI, Python, or a colleague's R session and it returns identical rows.
-That is the contract behind the [Integrated App](https://app.calcofi.io/int)
-download bundle's `query/` folder.
+DuckDB CLI, Python, a colleague's R session, or the browser-based
+**[Match app](match/)** and it returns identical rows. That is the contract
+behind the [Integrated App](https://app.calcofi.io/int) download bundle's
+`query/` folder.
 
 To get the SQL **without running it** — e.g. to serialize or inspect it — pass
 `return_sql = TRUE`:
@@ -111,6 +112,22 @@ To get the SQL **without running it** — e.g. to serialize or inspect it — pa
 sql <- cc_match_ichthyo_by_name("Sardinops sagax", return_sql = TRUE)
 cat(sql)
 ```
+
+## Run it from anywhere
+
+The portable SQL these helpers emit runs in any DuckDB client:
+
+| Where | How |
+|---|---|
+| **R**, on your laptop | `cc_match_ichthyo_by_name(...)` — this page |
+| **Python**, on a notebook server | `duckdb.connect().sql(open("query.sql").read()).df()` — see [Data Access → From Python](data-access.qmd#from-python) |
+| **shell**, on the command line | `duckdb < query.sql` |
+| **your web browser**, no install | **[CalCOFI Match](match/)** — point-and-click form for the three wrappers + custom SQL, runs DuckDB-WASM client-side |
+
+In each case the *exact same* generated SQL hits the *exact same* public GCS
+Parquet, so a colleague who only writes Python (or only opens browser tabs)
+gets the same rows you do — same `bio_id`s, same `env_value`s, same
+`time_diff_hr`s.
 
 ## The core engine: `cc_match_bio_env()`
 

--- a/match/app.js
+++ b/match/app.js
@@ -1,0 +1,332 @@
+// app.js — UI + runtime for CalCOFI Match.
+//
+// Wires the form to docs/match/match.js (the SQL builders) and to DuckDB-WASM
+// (loaded lazily from jsDelivr). The page never talks to any CalCOFI service:
+// the only network traffic is the wasm bundle from jsDelivr and Parquet range
+// requests to storage.googleapis.com.
+
+import {
+  VERSION as MATCH_JS_VERSION,
+  matchBioEnv,
+  matchIchthyoByName,
+  matchIchthyoByTaxon,
+  matchZooplanktonBiomass,
+  buildBioSQLIchthyo,
+  buildEnvSQL,
+  extractSourceUrls,
+  SQL_HEADER
+} from "./match.js";
+
+// Common measurement_types — also queryable from measurement_type.parquet, but
+// pre-listed so the form is usable before the wasm bundle finishes loading.
+const ENV_VARS = [
+  "temperature", "salinity", "oxygen_umol_kg", "phosphate", "silicate",
+  "nitrite", "nitrate", "chlorophyll_a", "phaeopigment", "dynamic_height",
+  "sigma_theta", "pressure", "par", "ph", "ammonia"
+];
+
+// ── tiny DOM helpers ───────────────────────────────────────────────────────
+const $  = (sel, root = document) => root.querySelector(sel);
+const $$ = (sel, root = document) => Array.from(root.querySelectorAll(sel));
+
+// ── status pill ────────────────────────────────────────────────────────────
+const statusEl = $("#status");
+let _statusTimer = null;
+function setStatus(text, kind = "idle") {
+  statusEl.className = kind === "idle" ? "" : kind;
+  statusEl.innerHTML = text;
+  if (_statusTimer) { clearTimeout(_statusTimer); _statusTimer = null; }
+}
+
+// ── form ↔ args ────────────────────────────────────────────────────────────
+function readForm(form) {
+  const o = {};
+  for (const el of form.elements) {
+    if (!el.name) continue;
+    if (el.type === "checkbox") o[el.name] = el.checked;
+    else if (el.type === "radio") { if (el.checked) o[el.name] = el.value; }
+    else if (el.type === "number") {
+      o[el.name] = el.value === "" ? null : Number(el.value);
+    } else {
+      o[el.name] = el.value === "" ? null : el.value;
+    }
+  }
+  return o;
+}
+
+// ── populate env_var <select>s ─────────────────────────────────────────────
+for (const sel of $$("select[data-env-var]")) {
+  for (const v of ENV_VARS) {
+    const opt = document.createElement("option");
+    opt.value = v; opt.textContent = v;
+    if (v === "temperature") opt.selected = true;
+    sel.appendChild(opt);
+  }
+}
+
+// ── tabs ───────────────────────────────────────────────────────────────────
+$("#tabs").addEventListener("click", (e) => {
+  const btn = e.target.closest("button[data-tab]");
+  if (!btn) return;
+  const tab = btn.dataset.tab;
+  for (const b of $$("#tabs button")) b.setAttribute("aria-selected", b === btn);
+  for (const f of $$("form.match-form")) f.classList.toggle("hidden", f.dataset.tab !== tab);
+});
+
+// ── subtabs (Results / SQL / Metadata) ─────────────────────────────────────
+$("#subtabs").addEventListener("click", (e) => {
+  const btn = e.target.closest("button[data-subtab]");
+  if (!btn) return;
+  const sub = btn.dataset.subtab;
+  for (const b of $$("#subtabs button")) b.setAttribute("aria-selected", b === btn);
+  $("#panel-results").classList.toggle("hidden", sub !== "results");
+  $("#panel-sql"    ).classList.toggle("hidden", sub !== "sql");
+  $("#panel-meta"   ).classList.toggle("hidden", sub !== "meta");
+});
+
+// ── custom-tab pre-fill: the worked-example bio + env CTEs ─────────────────
+{
+  const version = "v2026.05.14";
+  $("#cu-bio").value = buildBioSQLIchthyo({
+    version,
+    species_where: "sp.scientific_name IN ('Sardinops sagax')",
+    life_stage: "larva",
+    date_min: "2018-01-01", date_max: "2018-03-31"
+  });
+  $("#cu-env").value = buildEnvSQL({
+    env_var: "temperature", version,
+    date_min: "2018-01-01", date_max: "2018-03-31",
+    pad_hours: 72
+  });
+}
+$("#sh-example").addEventListener("click", () => {
+  $("#sh-sql").value =
+`SELECT scientific_name, common_name, worms_id
+FROM read_parquet(
+  'https://storage.googleapis.com/calcofi-db/ducklake/releases/v2026.05.14/parquet/species.parquet')
+WHERE common_name ILIKE '%sardine%'
+ORDER BY scientific_name;`;
+});
+
+// ── DuckDB-WASM (lazy) ─────────────────────────────────────────────────────
+const DUCKDB_VERSION = "1.29.0";
+let _duckdb = null, _conn = null;
+
+async function getConn() {
+  if (_conn) return _conn;
+  setStatus("Loading DuckDB-WASM bundle from jsDelivr…", "busy");
+  const duckdb = await import(
+    `https://cdn.jsdelivr.net/npm/@duckdb/duckdb-wasm@${DUCKDB_VERSION}/+esm`);
+  _duckdb = duckdb;
+  const bundles = duckdb.getJsDelivrBundles();
+  const bundle  = await duckdb.selectBundle(bundles);
+  setStatus("Initializing DuckDB-WASM…", "busy");
+  const worker = await duckdb.createWorker(bundle.mainWorker);
+  const db = new duckdb.AsyncDuckDB(new duckdb.ConsoleLogger(), worker);
+  await db.instantiate(bundle.mainModule, bundle.pthreadWorker);
+  const conn = await db.connect();
+  await conn.query("INSTALL httpfs; LOAD httpfs;");
+  await conn.query("INSTALL spatial; LOAD spatial;");
+  _conn = conn;
+  return conn;
+}
+
+// ── arrow-table → JS plain rows ────────────────────────────────────────────
+function arrowToRows(arrow) {
+  // Use toArray() then JSON-round-trip for stable JS-native values.
+  // BigInts → numbers (via replacer) so they render & CSV-serialize cleanly.
+  const raw = arrow.toArray().map(r => r.toJSON ? r.toJSON() : r);
+  const fields = arrow.schema.fields.map(f => f.name);
+  return raw.map(row => {
+    const o = {};
+    for (const f of fields) {
+      let v = row[f];
+      if (typeof v === "bigint") v = Number(v);
+      else if (v instanceof Date) v = v.toISOString();
+      else if (v && typeof v === "object" && v.toString) v = v.toString();
+      o[f] = v;
+    }
+    return o;
+  });
+}
+
+// ── render results table (paginated, sortable) ─────────────────────────────
+const PAGE_SIZE = 100;
+const state = { rows: [], cols: [], sortCol: null, sortDir: 1, page: 0 };
+
+function renderTable() {
+  const wrap = $("#table-wrap");
+  if (!state.rows.length) {
+    wrap.innerHTML = `<p style="padding:1rem;color:#5d6d7e">No rows.</p>`;
+    $("#pagination").innerHTML = "";
+    return;
+  }
+  const sorted = state.sortCol == null ? state.rows : [...state.rows].sort((a, b) => {
+    const av = a[state.sortCol], bv = b[state.sortCol];
+    if (av == null && bv == null) return 0;
+    if (av == null) return 1;
+    if (bv == null) return -1;
+    if (av < bv) return -1 * state.sortDir;
+    if (av > bv) return  1 * state.sortDir;
+    return 0;
+  });
+  const start = state.page * PAGE_SIZE;
+  const page  = sorted.slice(start, start + PAGE_SIZE);
+
+  const isNum = c => page.every(r => r[c] == null || typeof r[c] === "number");
+
+  const html = [
+    "<table class='results'><thead><tr>",
+    state.cols.map(c => {
+      const arrow = state.sortCol === c ? (state.sortDir > 0 ? " ▲" : " ▼") : "";
+      return `<th data-col="${c}" class="${isNum(c) ? "num" : ""}" style="cursor:pointer">${c}${arrow}</th>`;
+    }).join(""),
+    "</tr></thead><tbody>",
+    page.map(r => "<tr>" + state.cols.map(c => {
+      const v = r[c];
+      const cls = typeof v === "number" ? "num" : "";
+      const shown = v == null ? "" :
+                    typeof v === "number" ? (Number.isInteger(v) ? v : v.toFixed(4)) :
+                    String(v);
+      return `<td class="${cls}">${escHtml(shown)}</td>`;
+    }).join("") + "</tr>").join(""),
+    "</tbody></table>"
+  ].join("");
+  wrap.innerHTML = html;
+
+  const total = sorted.length;
+  const pages = Math.ceil(total / PAGE_SIZE);
+  $("#pagination").innerHTML = pages <= 1 ? "" : `
+    <button id="pg-prev" ${state.page === 0 ? "disabled" : ""}>← prev</button>
+    <span>page ${state.page + 1} of ${pages} (rows ${start + 1}–${Math.min(start + PAGE_SIZE, total)} of ${total})</span>
+    <button id="pg-next" ${state.page >= pages - 1 ? "disabled" : ""}>next →</button>`;
+}
+function escHtml(s) { return String(s).replace(/[&<>"']/g, c => ({"&":"&amp;","<":"&lt;",">":"&gt;",'"':"&quot;","'":"&#39;"}[c])); }
+
+$("#table-wrap").addEventListener("click", (e) => {
+  const th = e.target.closest("th[data-col]");
+  if (!th) return;
+  const col = th.dataset.col;
+  if (state.sortCol === col) state.sortDir *= -1;
+  else { state.sortCol = col; state.sortDir = 1; }
+  state.page = 0;
+  renderTable();
+});
+$("#pagination").addEventListener("click", (e) => {
+  if (e.target.id === "pg-prev" && state.page > 0)   { state.page--; renderTable(); }
+  if (e.target.id === "pg-next") { state.page++; renderTable(); }
+});
+
+// ── download CSV / copy + download SQL ─────────────────────────────────────
+function rowsToCSV(cols, rows) {
+  const esc = v => v == null ? "" :
+    /[",\n]/.test(String(v)) ? `"${String(v).replace(/"/g, '""')}"` : String(v);
+  return cols.join(",") + "\n" + rows.map(r => cols.map(c => esc(r[c])).join(",")).join("\n") + "\n";
+}
+function download(name, mime, body) {
+  const blob = new Blob([body], { type: mime });
+  const url  = URL.createObjectURL(blob);
+  const a    = document.createElement("a");
+  a.href = url; a.download = name; document.body.appendChild(a); a.click();
+  setTimeout(() => { document.body.removeChild(a); URL.revokeObjectURL(url); }, 0);
+}
+$("#dl-csv").addEventListener("click", () =>
+  download(`calcofi_match_${Date.now()}.csv`, "text/csv", rowsToCSV(state.cols, state.rows)));
+$("#dl-sql").addEventListener("click", () => {
+  const sql = $("#sql-text").textContent;
+  download(`calcofi_match_${Date.now()}.sql`, "text/plain", SQL_HEADER + sql + "\n");
+});
+$("#copy-sql").addEventListener("click", async () => {
+  await navigator.clipboard.writeText(SQL_HEADER + $("#sql-text").textContent + "\n");
+  const btn = $("#copy-sql"), prev = btn.textContent;
+  btn.textContent = "✓ copied"; setTimeout(() => { btn.textContent = prev; }, 1200);
+});
+
+// ── run! ───────────────────────────────────────────────────────────────────
+async function run(form) {
+  const tab = form.dataset.tab;
+  const args = readForm(form);
+  const submitBtn = $("button[type=submit]", form);
+  submitBtn.disabled = true;
+
+  let sql, queryMeta;
+  try {
+    if (tab === "by-name") {
+      ({ sql, queryMeta } = matchIchthyoByName(args));
+    } else if (tab === "by-taxon") {
+      ({ sql, queryMeta } = matchIchthyoByTaxon(args));
+    } else if (tab === "zoo") {
+      ({ sql, queryMeta } = matchZooplanktonBiomass(args));
+    } else if (tab === "custom") {
+      ({ sql, queryMeta } = matchBioEnv(args));
+    } else if (tab === "shell") {
+      sql = args.sql;
+      queryMeta = {
+        match_js_version: MATCH_JS_VERSION,
+        release_version:  args.version || null,
+        params:           { mode: "shell" },
+        source_urls:      extractSourceUrls(sql),
+        generated_at:     new Date().toISOString().replace("T", " ").replace(/\.\d+Z$/, " UTC")
+      };
+    }
+  } catch (err) {
+    setStatus(`✗ SQL build failed: ${escHtml(err.message)}`, "error");
+    submitBtn.disabled = false;
+    return;
+  }
+
+  const conn = await getConn().catch(err => {
+    setStatus(`✗ DuckDB-WASM init failed: ${escHtml(err.message)}`, "error");
+    submitBtn.disabled = false;
+    return null;
+  });
+  if (!conn) return;
+
+  const t0 = performance.now();
+  setStatus(`Running query against <code>${escHtml(queryMeta.source_urls?.[0]?.split('/').slice(0,7).join('/') || 'GCS')}</code>…`, "busy");
+  try {
+    const arrow = await conn.query(sql);
+    const rows  = arrowToRows(arrow);
+    const cols  = arrow.schema.fields.map(f => f.name);
+    const sec   = ((performance.now() - t0) / 1000).toFixed(1);
+
+    state.rows = rows; state.cols = cols; state.page = 0;
+    state.sortCol = null; state.sortDir = 1;
+
+    if (tab !== "shell") queryMeta.n_rows = rows.length;
+
+    $("#output").classList.remove("hidden");
+    $("#row-count").innerHTML = `<strong>${rows.length}</strong> row${rows.length === 1 ? "" : "s"} · ${cols.length} cols · ${sec}s`;
+    $("#sql-text").textContent = sql;
+    $("#meta-text").textContent = JSON.stringify(queryMeta, null, 2);
+    renderTable();
+
+    setStatus(`✓ Done: ${rows.length} row${rows.length === 1 ? "" : "s"} in ${sec}s`, "success");
+  } catch (err) {
+    setStatus(`✗ Query failed: ${escHtml(err.message)}`, "error");
+    // still show the SQL so the user can see what was attempted
+    $("#output").classList.remove("hidden");
+    $("#sql-text").textContent = sql;
+    $("#meta-text").textContent = JSON.stringify(queryMeta, null, 2);
+    // switch to SQL panel so user sees the query
+    $$("#subtabs button").forEach(b => b.setAttribute("aria-selected", b.dataset.subtab === "sql"));
+    $("#panel-results").classList.add("hidden");
+    $("#panel-sql").classList.remove("hidden");
+    $("#panel-meta").classList.add("hidden");
+  } finally {
+    submitBtn.disabled = false;
+  }
+}
+
+for (const form of $$("form.match-form")) {
+  form.addEventListener("submit", (e) => { e.preventDefault(); run(form); });
+}
+
+// ── deep link: ?version=vYYYY.MM.DD overrides every version input ──────────
+{
+  const u = new URL(location.href);
+  const v = u.searchParams.get("version");
+  if (v && /^v\d{4}\.\d{2}/.test(v)) {
+    for (const el of $$("input[data-version]")) el.value = v;
+  }
+}

--- a/match/index.html
+++ b/match/index.html
@@ -1,0 +1,336 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>CalCOFI Match — query 75 years of ocean data in your browser</title>
+  <meta name="description" content="Browser-only client for the three retired CalCOFI Plumber-API bio↔env matching endpoints, running DuckDB-WASM against public Parquet on Google Cloud Storage.">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<header>
+  <h1>CalCOFI Match <span class="badge">DuckDB-WASM</span></h1>
+  <p class="lead">
+    Query 75 years of California Current oceanography <strong>in your browser</strong>
+    — no install, no credentials, no server. The three retired Plumber-API bio↔env
+    endpoints (<code>ichthyodata</code>, <code>itis_ichthyodata</code>,
+    <code>zooplankton_biomass</code>), plus a free-form SQL shell, all running on
+    <a href="https://duckdb.org/docs/api/wasm/overview.html">DuckDB-WASM</a> +
+    public <a href="https://storage.googleapis.com/calcofi-db/ducklake/releases/">CalCOFI Parquet on GCS</a>.
+    The emitted SQL is character-identical to
+    <a href="https://calcofi.io/calcofi4r/reference/cc_match_bio_env.html"><code>calcofi4r::cc_match_*()</code></a>'s
+    <code>attr(d,&nbsp;"sql")</code> — see the
+    <a href="../helpers.html">Matching Helpers</a> chapter for the story.
+  </p>
+</header>
+
+<div id="status">Idle — fill the form and click <strong>Run</strong>. First click loads the DuckDB-WASM engine (~5 s).</div>
+
+<nav class="tabs" role="tablist" id="tabs">
+  <button role="tab" data-tab="by-name"  aria-selected="true">by name</button>
+  <button role="tab" data-tab="by-taxon" aria-selected="false">by taxon</button>
+  <button role="tab" data-tab="zoo"      aria-selected="false">zoo biomass</button>
+  <button role="tab" data-tab="custom"   aria-selected="false">custom (bio + env)</button>
+  <button role="tab" data-tab="shell"    aria-selected="false">SQL shell</button>
+</nav>
+
+<main>
+
+  <!-- ─────────── by name ─────────── -->
+  <form class="match-form" id="form-by-name" data-tab="by-name">
+    <div class="field span-2">
+      <label for="bn-scientific_name">scientific_name</label>
+      <input id="bn-scientific_name" name="scientific_name" type="text"
+             value="Sardinops sagax" required>
+      <span class="hint">Exact match against <code>species.scientific_name</code>. Mirrors <code>cc_match_ichthyo_by_name(scientific_name=)</code>.</span>
+    </div>
+    <div class="field">
+      <label for="bn-env_var">env_var</label>
+      <select id="bn-env_var" name="env_var" data-env-var></select>
+      <span class="hint"><code>bottle_measurement.measurement_type</code></span>
+    </div>
+    <div class="field check">
+      <span class="label">exact_match</span>
+      <div class="opts">
+        <label><input type="checkbox" name="exact_match" checked> exact (else <code>ILIKE</code>)</label>
+      </div>
+    </div>
+    <div class="field radio">
+      <span class="label">life_stage</span>
+      <div class="opts">
+        <label><input type="radio" name="life_stage" value="">any</label>
+        <label><input type="radio" name="life_stage" value="egg">egg</label>
+        <label><input type="radio" name="life_stage" value="larva" checked>larva</label>
+      </div>
+    </div>
+    <div class="field">
+      <label for="bn-date_min">date_min</label>
+      <input id="bn-date_min" name="date_min" type="date" value="2018-01-01">
+    </div>
+    <div class="field">
+      <label for="bn-date_max">date_max</label>
+      <input id="bn-date_max" name="date_max" type="date" value="2018-03-31">
+      <span class="hint">CTD-bottle env data ends 2021-05; Q1 2018 has overlap.</span>
+    </div>
+    <div class="field">
+      <label for="bn-depth_m_min">depth_m_min <span class="hint">(optional)</span></label>
+      <input id="bn-depth_m_min" name="depth_m_min" type="number" step="any" placeholder="0">
+    </div>
+    <div class="field">
+      <label for="bn-depth_m_max">depth_m_max <span class="hint">(optional)</span></label>
+      <input id="bn-depth_m_max" name="depth_m_max" type="number" step="any" placeholder="500">
+    </div>
+    <div class="field check">
+      <span class="label">relax_matching</span>
+      <div class="opts">
+        <label><input type="checkbox" name="relax_matching" checked> 5 km / 72 hr (else 2 km / 6 hr)</label>
+      </div>
+    </div>
+    <div class="field">
+      <label for="bn-max_dist_km">max_dist_km <span class="hint">(override)</span></label>
+      <input id="bn-max_dist_km" name="max_dist_km" type="number" step="any" placeholder="auto">
+    </div>
+    <div class="field">
+      <label for="bn-max_time_hr">max_time_hr <span class="hint">(override)</span></label>
+      <input id="bn-max_time_hr" name="max_time_hr" type="number" step="any" placeholder="auto">
+    </div>
+    <div class="field radio">
+      <span class="label">join_method</span>
+      <div class="opts">
+        <label><input type="radio" name="join_method" value="nearest_time" checked>nearest_time</label>
+        <label><input type="radio" name="join_method" value="nearest_dist">nearest_dist</label>
+        <label><input type="radio" name="join_method" value="average">average</label>
+      </div>
+    </div>
+    <div class="field">
+      <label for="bn-version">version</label>
+      <input id="bn-version" name="version" type="text" value="v2026.05.14" data-version>
+    </div>
+    <div class="form-actions">
+      <button type="submit" class="run">Run</button>
+      <span class="hint">Replaces the old <code>/ichthyodata</code> endpoint.</span>
+    </div>
+  </form>
+
+  <!-- ─────────── by taxon ─────────── -->
+  <form class="match-form hidden" id="form-by-taxon" data-tab="by-taxon">
+    <div class="field">
+      <label for="bt-worms_id">worms_id</label>
+      <input id="bt-worms_id" name="worms_id" type="number" step="1" min="1"
+             value="125724" required>
+      <span class="hint">WoRMS <code>taxonID</code>; matches that id AND every descendant via a recursive walk of <code>taxon.parentNameUsageID</code>. <code>125724</code> = genus <em>Engraulis</em>.</span>
+    </div>
+    <div class="field">
+      <label for="bt-env_var">env_var</label>
+      <select id="bt-env_var" name="env_var" data-env-var></select>
+    </div>
+    <div class="field radio">
+      <span class="label">life_stage</span>
+      <div class="opts">
+        <label><input type="radio" name="life_stage" value="" checked>any</label>
+        <label><input type="radio" name="life_stage" value="egg">egg</label>
+        <label><input type="radio" name="life_stage" value="larva">larva</label>
+      </div>
+    </div>
+    <div class="field">
+      <label for="bt-date_min">date_min</label>
+      <input id="bt-date_min" name="date_min" type="date" value="2018-01-01">
+    </div>
+    <div class="field">
+      <label for="bt-date_max">date_max</label>
+      <input id="bt-date_max" name="date_max" type="date" value="2018-03-31">
+    </div>
+    <div class="field check">
+      <span class="label">relax_matching</span>
+      <div class="opts">
+        <label><input type="checkbox" name="relax_matching" checked> 5 km / 72 hr</label>
+      </div>
+    </div>
+    <div class="field">
+      <label for="bt-max_dist_km">max_dist_km</label>
+      <input id="bt-max_dist_km" name="max_dist_km" type="number" step="any" placeholder="auto">
+    </div>
+    <div class="field">
+      <label for="bt-max_time_hr">max_time_hr</label>
+      <input id="bt-max_time_hr" name="max_time_hr" type="number" step="any" placeholder="auto">
+    </div>
+    <div class="field radio">
+      <span class="label">join_method</span>
+      <div class="opts">
+        <label><input type="radio" name="join_method" value="nearest_time" checked>nearest_time</label>
+        <label><input type="radio" name="join_method" value="nearest_dist">nearest_dist</label>
+        <label><input type="radio" name="join_method" value="average">average</label>
+      </div>
+    </div>
+    <div class="field">
+      <label for="bt-version">version</label>
+      <input id="bt-version" name="version" type="text" value="v2026.05.14" data-version>
+    </div>
+    <div class="form-actions">
+      <button type="submit" class="run">Run</button>
+      <span class="hint">Replaces the old <code>/itis_ichthyodata</code> endpoint (WoRMS replaces ITIS-path regex).</span>
+    </div>
+  </form>
+
+  <!-- ─────────── zoo biomass ─────────── -->
+  <form class="match-form hidden" id="form-zoo" data-tab="zoo">
+    <div class="field radio">
+      <span class="label">biomass_type</span>
+      <div class="opts">
+        <label><input type="radio" name="biomass_type" value="totalplankton" checked>totalplankton</label>
+        <label><input type="radio" name="biomass_type" value="smallplankton">smallplankton</label>
+      </div>
+      <span class="hint">Net-tow displacement-volume biomass (mL).</span>
+    </div>
+    <div class="field">
+      <label for="zo-env_var">env_var</label>
+      <select id="zo-env_var" name="env_var" data-env-var></select>
+    </div>
+    <div class="field">
+      <label for="zo-date_min">date_min</label>
+      <input id="zo-date_min" name="date_min" type="date" value="2018-01-01">
+    </div>
+    <div class="field">
+      <label for="zo-date_max">date_max</label>
+      <input id="zo-date_max" name="date_max" type="date" value="2018-12-31">
+    </div>
+    <div class="field check">
+      <span class="label">relax_matching</span>
+      <div class="opts">
+        <label><input type="checkbox" name="relax_matching" checked> 5 km / 72 hr</label>
+      </div>
+    </div>
+    <div class="field">
+      <label for="zo-max_dist_km">max_dist_km</label>
+      <input id="zo-max_dist_km" name="max_dist_km" type="number" step="any" placeholder="auto">
+    </div>
+    <div class="field">
+      <label for="zo-max_time_hr">max_time_hr</label>
+      <input id="zo-max_time_hr" name="max_time_hr" type="number" step="any" placeholder="auto">
+    </div>
+    <div class="field radio">
+      <span class="label">join_method</span>
+      <div class="opts">
+        <label><input type="radio" name="join_method" value="nearest_time" checked>nearest_time</label>
+        <label><input type="radio" name="join_method" value="nearest_dist">nearest_dist</label>
+        <label><input type="radio" name="join_method" value="average">average</label>
+      </div>
+    </div>
+    <div class="field">
+      <label for="zo-version">version</label>
+      <input id="zo-version" name="version" type="text" value="v2026.05.14" data-version>
+    </div>
+    <div class="form-actions">
+      <button type="submit" class="run">Run</button>
+      <span class="hint">Replaces the old <code>/zooplankton_biomass</code> endpoint.</span>
+    </div>
+  </form>
+
+  <!-- ─────────── custom (bio + env) ─────────── -->
+  <form class="match-form hidden full" id="form-custom" data-tab="custom">
+    <p class="hint" style="margin: 0 0 0.5rem;">
+      Power-user mode: drop in your own <code>bio</code> and <code>env</code>
+      <code>SELECT</code> sub-queries. Both must read from
+      <code>read_parquet('https://storage.googleapis.com/calcofi-db/.../{table}.parquet')</code>
+      and produce the contract columns documented in
+      <a href="https://calcofi.io/calcofi4r/reference/cc_match_bio_env.html"><code>?cc_match_bio_env</code></a>:
+      <code>bio</code> → <code>bio_id, bio_datetime, bio_lon, bio_lat, bio_value</code>;
+      <code>env</code> → <code>env_id, env_datetime, env_lon, env_lat, env_value, env_depth_m, measurement_type</code>.
+    </p>
+    <div class="field span-all">
+      <label for="cu-bio">bio (<code>SELECT</code> string)</label>
+      <textarea id="cu-bio" name="bio" rows="11" required></textarea>
+    </div>
+    <div class="field span-all">
+      <label for="cu-env">env (<code>SELECT</code> string)</label>
+      <textarea id="cu-env" name="env" rows="10" required></textarea>
+    </div>
+    <div class="field">
+      <label for="cu-max_dist_km">max_dist_km</label>
+      <input id="cu-max_dist_km" name="max_dist_km" type="number" step="any" value="5">
+    </div>
+    <div class="field">
+      <label for="cu-max_time_hr">max_time_hr</label>
+      <input id="cu-max_time_hr" name="max_time_hr" type="number" step="any" value="72">
+    </div>
+    <div class="field radio">
+      <span class="label">join_method</span>
+      <div class="opts">
+        <label><input type="radio" name="join_method" value="nearest_time" checked>nearest_time</label>
+        <label><input type="radio" name="join_method" value="nearest_dist">nearest_dist</label>
+        <label><input type="radio" name="join_method" value="average">average</label>
+      </div>
+    </div>
+    <div class="field">
+      <label for="cu-version">version</label>
+      <input id="cu-version" name="version" type="text" value="v2026.05.14" data-version>
+    </div>
+    <div class="form-actions">
+      <button type="submit" class="run">Run</button>
+      <span class="hint">Mirrors <code>cc_match_bio_env(bio, env, ...)</code>.</span>
+    </div>
+  </form>
+
+  <!-- ─────────── shell ─────────── -->
+  <form class="match-form hidden full" id="form-shell" data-tab="shell">
+    <p class="hint" style="margin: 0 0 0.5rem;">
+      Run any DuckDB SQL against the release Parquet — same engine as the wrapped tabs.
+      The <code>httpfs</code> and <code>spatial</code> extensions are already loaded.
+    </p>
+    <div class="field span-all">
+      <label for="sh-sql">SQL</label>
+      <textarea id="sh-sql" name="sql" rows="11" required></textarea>
+    </div>
+    <div class="form-actions">
+      <button type="submit" class="run">Run</button>
+      <button type="button" class="secondary" id="sh-example">Load example</button>
+    </div>
+  </form>
+
+</main>
+
+<section id="output" class="hidden">
+  <nav class="subtabs" role="tablist" id="subtabs">
+    <button role="tab" data-subtab="results" aria-selected="true">Results</button>
+    <button role="tab" data-subtab="sql"     aria-selected="false">SQL</button>
+    <button role="tab" data-subtab="meta"    aria-selected="false">Metadata</button>
+  </nav>
+
+  <div id="panel-results" class="subpanel">
+    <div class="result-toolbar">
+      <span id="row-count"></span>
+      <span class="spacer"></span>
+      <button class="secondary" id="dl-csv">Download CSV</button>
+    </div>
+    <div id="table-wrap"></div>
+    <div class="pagination" id="pagination"></div>
+  </div>
+
+  <div id="panel-sql" class="subpanel hidden">
+    <div class="result-toolbar">
+      <span class="hint">Fully interpolated, copy-paste runnable in any DuckDB client.</span>
+      <span class="spacer"></span>
+      <button class="secondary" id="copy-sql">Copy SQL</button>
+      <button class="secondary" id="dl-sql">Download <code>.sql</code></button>
+    </div>
+    <pre><code id="sql-text"></code></pre>
+  </div>
+
+  <div id="panel-meta" class="subpanel hidden">
+    <pre><code id="meta-text"></code></pre>
+  </div>
+</section>
+
+<footer>
+  Engine: <a href="https://duckdb.org/docs/api/wasm/overview.html">DuckDB-WASM</a> from
+  jsDelivr. SQL builder: <code><a href="match.js">match.js</a></code>, a 1:1 port of
+  <a href="https://github.com/CalCOFI/calcofi4r/blob/main/R/match.R"><code>calcofi4r/R/match.R</code></a>.
+  Source data: public Parquet on <code>gs://calcofi-db</code>
+  (<a href="https://storage.googleapis.com/calcofi-db/ducklake/releases/">browse releases</a>).
+  Code: <a href="https://github.com/CalCOFI/docs/tree/main/match"><code>CalCOFI/docs/match</code></a>.
+</footer>
+
+<script type="module" src="app.js"></script>
+</body>
+</html>

--- a/match/match.js
+++ b/match/match.js
@@ -1,0 +1,386 @@
+// match.js — browser/Node port of calcofi4r/R/match.R
+//
+// Pure SQL builders (no I/O) that produce the same DuckDB CTE queries
+// calcofi4r emits as `attr(d, "sql")`. The match*() wrappers return
+// { sql, queryMeta } so the caller can run sql in DuckDB-WASM (this page),
+// the duckdb CLI, Python, or any DuckDB client and get identical rows.
+//
+// 1:1 port: when calcofi4r/R/match.R changes, this file must follow.
+// SQL fidelity is asserted by docs/match/scripts/diff-r-vs-js.sh.
+
+export const VERSION = "0.1.0";
+
+const GCS_RELEASES = "https://storage.googleapis.com/calcofi-db/ducklake/releases";
+
+// "latest" resolver — synchronous version requires a pre-fetched pointer;
+// callers that need to resolve at runtime use resolveLatestVersion() below.
+export function parquetBase(version) {
+  if (!/^v\d{4}\.\d{2}/.test(version))
+    throw new Error(`Version must be in format vYYYY.MM[.DD] (got: ${version})`);
+  return `${GCS_RELEASES}/${version}/parquet`;
+}
+
+export async function resolveLatestVersion() {
+  const r = await fetch(`${GCS_RELEASES}/latest.txt`);
+  if (!r.ok) throw new Error(`Could not resolve 'latest' (${r.status})`);
+  return (await r.text()).trim();
+}
+
+// Pull the distinct read_parquet() URLs out of an emitted SQL string.
+export function extractSourceUrls(sql) {
+  const hits = sql.match(/read_parquet\('[^']+'/g) || [];
+  return [...new Set(hits.map(h => h.replace(/^read_parquet\('|'$/g, "")))].sort();
+}
+
+// SQL-escape a single quote in user input.
+function sqlEsc(s) { return String(s).replace(/'/g, "''"); }
+
+// ─── core engine ────────────────────────────────────────────────────────────
+// Mirror of .cc_build_match_sql + cc_match_bio_env (return_sql/collect ignored;
+// this builds the SQL only — the caller runs it).
+export function buildMatchSQL({ bio, env, max_dist_km, max_time_hr, join_method }) {
+  const where_nearest =
+    join_method === "nearest_time" ? "WHERE time_diff_hr = mn_time_diff_hr" :
+    join_method === "nearest_dist" ? "WHERE dist_km = mn_dist_km"           :
+    join_method === "average"      ? ""                                       :
+    (() => { throw new Error(`Unknown join_method: ${join_method}`); })();
+
+  // strip trailing ;/whitespace so nested CTEs concatenate cleanly
+  const bioTrim = String(bio).trim().replace(/;\s*$/, "");
+  const envTrim = String(env).trim().replace(/;\s*$/, "");
+
+  return `WITH bio AS (
+${bioTrim}
+),
+env AS (
+${envTrim}
+),
+matched AS (
+  -- temporal interval join: every env observation within ± max_time_hr
+  SELECT
+    bio.*,
+    env.* EXCLUDE (env_lon, env_lat),
+    abs(epoch(bio.bio_datetime) - epoch(env.env_datetime)) / 3600.0 AS time_diff_hr,
+    ST_Distance_Sphere(
+      ST_Point(bio.bio_lon, bio.bio_lat),
+      ST_Point(env.env_lon, env.env_lat)) / 1000.0                  AS dist_km
+  FROM bio
+  JOIN env
+    ON env.env_datetime BETWEEN bio.bio_datetime - INTERVAL '${max_time_hr} hours'
+                            AND bio.bio_datetime + INTERVAL '${max_time_hr} hours'
+),
+within AS (
+  -- spatial filter: keep pairs within max_dist_km
+  SELECT * FROM matched
+  WHERE dist_km <= ${max_dist_km}
+),
+ranked AS (
+  SELECT
+    *,
+    min(time_diff_hr) OVER (PARTITION BY bio_id) AS mn_time_diff_hr,
+    min(dist_km)      OVER (PARTITION BY bio_id) AS mn_dist_km
+  FROM within
+)
+-- one row per bio observation (× measurement_type): env values aggregated
+SELECT
+  * EXCLUDE (
+    env_id, env_value, env_datetime, env_depth_m,
+    time_diff_hr, dist_km, mn_time_diff_hr, mn_dist_km),
+  count(*)                                            AS n_env,
+  avg(env_value)                                      AS env_value,
+  CASE WHEN count(*) = 1 THEN 0
+       ELSE coalesce(stddev_samp(env_value), 0) END   AS env_value_sd,
+  avg(env_depth_m)                                    AS env_depth_m,
+  min(env_datetime)                                   AS env_datetime_min,
+  max(env_datetime)                                   AS env_datetime_max,
+  avg(dist_km)                                        AS dist_km,
+  avg(time_diff_hr)                                   AS time_diff_hr
+FROM ranked
+${where_nearest}
+GROUP BY ALL
+ORDER BY bio_id`;
+}
+
+// ─── env (CTD-bottle) subquery ──────────────────────────────────────────────
+// Mirror of .cc_env_sql
+export function buildEnvSQL({
+  env_var, version,
+  depth_m_min = null, depth_m_max = null,
+  date_min = null, date_max = null,
+  pad_hours = 0
+}) {
+  const base = parquetBase(version);
+
+  const filt = [
+    `bm.measurement_type = '${sqlEsc(env_var)}'`,
+    "bm.measurement_value IS NOT NULL",
+    "c.datetime_utc IS NOT NULL",
+    "c.lon_dec IS NOT NULL",
+    "c.lat_dec IS NOT NULL"
+  ];
+  if (depth_m_min != null && depth_m_min !== "")
+    filt.push(`b.depth_m >= ${Number(depth_m_min)}`);
+  if (depth_m_max != null && depth_m_max !== "")
+    filt.push(`b.depth_m <= ${Number(depth_m_max)}`);
+  if (date_min)
+    filt.push(`c.datetime_utc >= TIMESTAMP '${sqlEsc(date_min)}' - INTERVAL '${pad_hours} hours'`);
+  if (date_max)
+    filt.push(`c.datetime_utc <= TIMESTAMP '${sqlEsc(date_max)}' + INTERVAL '${pad_hours} hours'`);
+
+  // Indents are post-dedent (mirroring R glue::glue's .trim=TRUE behaviour):
+  // SELECT at col 0, body at col 2, FROM/JOIN/WHERE at col 0, AND continuations
+  // at col 4 (the filt rows are joined verbatim into the WHERE clause).
+  return `SELECT
+  bm.bottle_measurement_id AS env_id,
+  c.datetime_utc           AS env_datetime,
+  c.lon_dec                AS env_lon,
+  c.lat_dec                AS env_lat,
+  bm.measurement_value     AS env_value,
+  b.depth_m                AS env_depth_m,
+  bm.measurement_type      AS measurement_type
+FROM read_parquet('${base}/bottle_measurement.parquet') bm
+JOIN read_parquet('${base}/bottle.parquet') b ON bm.bottle_id = b.bottle_id
+JOIN read_parquet('${base}/casts.parquet')  c ON b.cast_id    = c.cast_id
+WHERE ${filt.join("\n    AND ")}`;
+}
+
+// ─── ichthyo bio subquery (shared by name + taxon wrappers) ─────────────────
+// Mirror of .cc_bio_sql_ichthyo
+export function buildBioSQLIchthyo({
+  version, species_where,
+  taxon_cte = null,
+  life_stage = null,
+  date_min = null, date_max = null
+}) {
+  const base = parquetBase(version);
+
+  const filt = [
+    "i.tally IS NOT NULL",
+    "i.measurement_type IS NULL",   // NULL measurement_type == count (tally) rows
+    "t.time_start IS NOT NULL",
+    "s.longitude IS NOT NULL",
+    "s.latitude IS NOT NULL"
+  ];
+  if (species_where) filt.push(species_where);
+  if (life_stage && life_stage.length) {
+    const stages = (Array.isArray(life_stage) ? life_stage : [life_stage])
+      .map(v => `'${sqlEsc(v)}'`).join(", ");
+    filt.push(`i.life_stage IN (${stages})`);
+  }
+  if (date_min) filt.push(`t.time_start >= TIMESTAMP '${sqlEsc(date_min)}'`);
+  if (date_max) filt.push(`t.time_start <= TIMESTAMP '${sqlEsc(date_max)}'`);
+
+  // No prefix: SELECT at col 0, body at col 2 (R glue dedents the template
+  // by its min common indent, which is 2). With a taxon_cte prefix the
+  // prepended "\n  " indents SELECT to col 2, matching the body. Either way
+  // FROM/JOIN/WHERE come out at col 0 and AND continuations at col 4.
+  const prefix = taxon_cte ? `${taxon_cte}\n  ` : "";
+
+  return `${prefix}SELECT
+  i.ichthyo_uuid::VARCHAR AS bio_id,
+  t.time_start            AS bio_datetime,
+  s.longitude             AS bio_lon,
+  s.latitude              AS bio_lat,
+  n.std_haul_factor * i.tally / nullif(n.prop_sorted, 0) AS bio_value,
+  sp.scientific_name,
+  sp.common_name,
+  sp.worms_id,
+  i.life_stage,
+  i.tally
+FROM read_parquet('${base}/ichthyo.parquet') i
+JOIN read_parquet('${base}/species.parquet') sp ON i.species_id = sp.species_id
+JOIN read_parquet('${base}/net.parquet')     n  ON i.net_uuid   = n.net_uuid
+JOIN read_parquet('${base}/tow.parquet')     t  ON n.tow_uuid   = t.tow_uuid
+JOIN read_parquet('${base}/site.parquet')    s  ON t.site_uuid  = s.site_uuid
+WHERE ${filt.join("\n    AND ")}`;
+}
+
+// ─── helpers shared by every wrapper ────────────────────────────────────────
+function defaultTolerances({ max_dist_km, max_time_hr, relax_matching }) {
+  return {
+    max_dist_km: max_dist_km != null && max_dist_km !== "" ? Number(max_dist_km) : (relax_matching ? 5  : 2),
+    max_time_hr: max_time_hr != null && max_time_hr !== "" ? Number(max_time_hr) : (relax_matching ? 72 : 6)
+  };
+}
+
+function makeQueryMeta(sql, { version, max_dist_km, max_time_hr, join_method }) {
+  return {
+    package_version: VERSION,
+    release_version: version,
+    params:          { max_dist_km, max_time_hr, join_method },
+    source_urls:     extractSourceUrls(sql),
+    generated_at:    new Date().toISOString().replace("T", " ").replace(/\.\d+Z$/, " UTC")
+  };
+}
+
+// ─── public match*() wrappers ───────────────────────────────────────────────
+
+// Mirror of cc_match_bio_env (bio + env strings supplied by caller).
+export function matchBioEnv({
+  bio, env,
+  max_dist_km = 2, max_time_hr = 6,
+  join_method = "nearest_time",
+  version
+}) {
+  if (!version) throw new Error("matchBioEnv() requires a resolved version (e.g. 'v2026.05.14')");
+  if (!bio || !env) throw new Error("matchBioEnv() needs both bio and env SELECT strings");
+  const sql = buildMatchSQL({ bio, env, max_dist_km, max_time_hr, join_method });
+  return { sql, queryMeta: makeQueryMeta(sql, { version, max_dist_km, max_time_hr, join_method }) };
+}
+
+// Mirror of cc_match_ichthyo_by_name
+export function matchIchthyoByName({
+  scientific_name,                  // string or string[]
+  env_var = "temperature",
+  exact_match = true,
+  life_stage = null,
+  date_min = null, date_max = null,
+  depth_m_min = null, depth_m_max = null,
+  max_dist_km = null, max_time_hr = null,
+  relax_matching = false,
+  join_method = "nearest_time",
+  version
+}) {
+  if (!version) throw new Error("matchIchthyoByName() requires a resolved version");
+  const names = (Array.isArray(scientific_name) ? scientific_name : [scientific_name])
+    .filter(Boolean);
+  if (!names.length) throw new Error("scientific_name must be a non-empty string or array");
+
+  const { max_dist_km: dk, max_time_hr: th } = defaultTolerances({ max_dist_km, max_time_hr, relax_matching });
+
+  const species_where = exact_match
+    ? `sp.scientific_name IN (${names.map(n => `'${sqlEsc(n)}'`).join(", ")})`
+    : `(${names.map(n => `sp.scientific_name ILIKE '%${sqlEsc(n)}%'`).join(" OR ")})`;
+
+  const bio = buildBioSQLIchthyo({
+    version, species_where,
+    life_stage, date_min, date_max
+  });
+  const env = buildEnvSQL({
+    env_var, version,
+    depth_m_min, depth_m_max,
+    date_min, date_max, pad_hours: th
+  });
+
+  const sql = buildMatchSQL({ bio, env, max_dist_km: dk, max_time_hr: th, join_method });
+  return { sql, queryMeta: makeQueryMeta(sql, { version, max_dist_km: dk, max_time_hr: th, join_method }) };
+}
+
+// Mirror of cc_match_ichthyo_by_taxon
+export function matchIchthyoByTaxon({
+  worms_id,                         // number or number[]
+  env_var = "temperature",
+  life_stage = null,
+  date_min = null, date_max = null,
+  depth_m_min = null, depth_m_max = null,
+  max_dist_km = null, max_time_hr = null,
+  relax_matching = false,
+  join_method = "nearest_time",
+  version
+}) {
+  if (!version) throw new Error("matchIchthyoByTaxon() requires a resolved version");
+  const ids = (Array.isArray(worms_id) ? worms_id : [worms_id])
+    .map(v => Number.parseInt(v, 10))
+    .filter(v => Number.isFinite(v));
+  if (!ids.length) throw new Error("worms_id must be a non-empty integer or integer array");
+
+  const { max_dist_km: dk, max_time_hr: th } = defaultTolerances({ max_dist_km, max_time_hr, relax_matching });
+  const base = parquetBase(version);
+
+  // recursive walk of the WoRMS taxon tree: seed taxa + every descendant.
+  // Post-dedent indents: WITH at col 0, inner SELECT/FROM/JOIN/WHERE at col 4,
+  // UNION ALL at col 2, closing ) at col 0.
+  const taxon_cte = `WITH RECURSIVE taxon_tree AS (
+    SELECT taxonID
+    FROM read_parquet('${base}/taxon.parquet')
+    WHERE authority = 'WoRMS' AND taxonID IN (${ids.join(", ")})
+  UNION ALL
+    SELECT t.taxonID
+    FROM read_parquet('${base}/taxon.parquet') t
+    JOIN taxon_tree tt ON t.parentNameUsageID = tt.taxonID
+    WHERE t.authority = 'WoRMS'
+)`;
+
+  const bio = buildBioSQLIchthyo({
+    version,
+    species_where: "sp.worms_id IN (SELECT taxonID FROM taxon_tree)",
+    taxon_cte,
+    life_stage, date_min, date_max
+  });
+  const env = buildEnvSQL({
+    env_var, version,
+    depth_m_min, depth_m_max,
+    date_min, date_max, pad_hours: th
+  });
+
+  const sql = buildMatchSQL({ bio, env, max_dist_km: dk, max_time_hr: th, join_method });
+  return { sql, queryMeta: makeQueryMeta(sql, { version, max_dist_km: dk, max_time_hr: th, join_method }) };
+}
+
+// Mirror of cc_match_zooplankton_biomass
+export function matchZooplanktonBiomass({
+  env_var = "temperature",
+  biomass_type = "totalplankton",   // or "smallplankton"
+  date_min = null, date_max = null,
+  depth_m_min = null, depth_m_max = null,
+  max_dist_km = null, max_time_hr = null,
+  relax_matching = false,
+  join_method = "nearest_time",
+  version
+}) {
+  if (!version) throw new Error("matchZooplanktonBiomass() requires a resolved version");
+  if (!["totalplankton", "smallplankton"].includes(biomass_type))
+    throw new Error(`biomass_type must be 'totalplankton' or 'smallplankton' (got: ${biomass_type})`);
+
+  const { max_dist_km: dk, max_time_hr: th } = defaultTolerances({ max_dist_km, max_time_hr, relax_matching });
+  const base = parquetBase(version);
+
+  const filt = [
+    `n.${biomass_type} IS NOT NULL`,
+    "t.time_start IS NOT NULL",
+    "s.longitude IS NOT NULL",
+    "s.latitude IS NOT NULL"
+  ];
+  if (date_min) filt.push(`t.time_start >= TIMESTAMP '${sqlEsc(date_min)}'`);
+  if (date_max) filt.push(`t.time_start <= TIMESTAMP '${sqlEsc(date_max)}'`);
+
+  // Same post-dedent shape as the env / no-prefix bio templates:
+  // SELECT (col 0), body (col 2), FROM/JOIN/WHERE (col 0), AND (col 4).
+  const bio = `SELECT
+  n.net_uuid::VARCHAR AS bio_id,
+  t.time_start        AS bio_datetime,
+  s.longitude         AS bio_lon,
+  s.latitude          AS bio_lat,
+  n.${biomass_type}    AS bio_value,
+  '${biomass_type}'    AS biomass_type,
+  n.side,
+  t.tow_type_key
+FROM read_parquet('${base}/net.parquet') n
+JOIN read_parquet('${base}/tow.parquet')  t ON n.tow_uuid  = t.tow_uuid
+JOIN read_parquet('${base}/site.parquet') s ON t.site_uuid = s.site_uuid
+WHERE ${filt.join("\n    AND ")}`;
+
+  const env = buildEnvSQL({
+    env_var, version,
+    depth_m_min, depth_m_max,
+    date_min, date_max, pad_hours: th
+  });
+
+  const sql = buildMatchSQL({ bio, env, max_dist_km: dk, max_time_hr: th, join_method });
+  return { sql, queryMeta: makeQueryMeta(sql, { version, max_dist_km: dk, max_time_hr: th, join_method }) };
+}
+
+// Sentence header to write atop emitted .sql files so they're copy-paste runnable.
+export const SQL_HEADER = [
+  "-- Re-run in DuckDB (CLI, Python or R) against public CalCOFI release",
+  "-- parquet. See https://calcofi.io/docs/data-access.html#reproducibility.",
+  "INSTALL httpfs; LOAD httpfs;",
+  "INSTALL spatial; LOAD spatial;",
+  "",
+  ""
+].join("\n");
+
+// Convenience: take a {sql} result and prefix the INSTALL/LOAD header.
+export function withRunnableHeader(sql) {
+  return SQL_HEADER + sql + "\n";
+}

--- a/match/style.css
+++ b/match/style.css
@@ -1,0 +1,339 @@
+/* CalCOFI Match — style.css
+   Light, accessible. Echoes the docs cosmo Bootswatch palette. */
+
+:root {
+  --fg:        #2c3e50;
+  --muted:    #5d6d7e;
+  --bg:       #ffffff;
+  --panel:    #f8f9fa;
+  --border:   #dee2e6;
+  --accent:   #2780e3;  /* cosmo primary */
+  --accent-d: #1c69bf;
+  --warn:     #ff7518;
+  --error:    #ff0039;
+  --success:  #3fb618;
+  --mono:     ui-monospace, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
+  --sans:     system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+}
+
+* { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+  font-family: var(--sans);
+  font-size: 15px;
+  line-height: 1.5;
+  color: var(--fg);
+  background: var(--bg);
+}
+
+body {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 1.25rem 1.5rem 4rem;
+}
+
+a { color: var(--accent); }
+a:hover { color: var(--accent-d); }
+
+header { margin-bottom: 1rem; }
+header h1 {
+  margin: 0 0 0.25rem;
+  font-size: 1.75rem;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+header h1 .badge {
+  display: inline-block;
+  font-size: 0.7rem;
+  font-weight: 600;
+  color: var(--bg);
+  background: var(--accent);
+  border-radius: 999px;
+  padding: 0.15em 0.6em;
+  vertical-align: 0.3em;
+  letter-spacing: 0.04em;
+}
+header p.lead {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+header p.lead strong { color: var(--fg); }
+
+/* ── status pill ─────────────────────────────────────────────────────────── */
+
+#status {
+  margin: 1rem 0;
+  padding: 0.5rem 0.85rem;
+  border-radius: 4px;
+  font-family: var(--mono);
+  font-size: 0.85rem;
+  background: var(--panel);
+  border-left: 4px solid var(--border);
+  color: var(--muted);
+}
+#status.busy    { border-left-color: var(--warn);    color: var(--fg); }
+#status.success { border-left-color: var(--success); color: var(--fg); }
+#status.error   {
+  border-left-color: var(--error);
+  color: var(--error);
+  background: #ffeef0;
+}
+
+/* ── tabs ────────────────────────────────────────────────────────────────── */
+
+nav.tabs, nav.subtabs {
+  display: flex;
+  gap: 0.25rem;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 1rem;
+  overflow-x: auto;
+}
+nav.tabs button, nav.subtabs button {
+  background: transparent;
+  border: none;
+  border-bottom: 2px solid transparent;
+  padding: 0.5rem 0.9rem;
+  font-family: inherit;
+  font-size: 0.95rem;
+  color: var(--muted);
+  cursor: pointer;
+  white-space: nowrap;
+  transition: color 0.15s, border-color 0.15s;
+}
+nav.tabs button:hover, nav.subtabs button:hover { color: var(--fg); }
+nav.tabs button[aria-selected="true"],
+nav.subtabs button[aria-selected="true"] {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+  font-weight: 600;
+}
+nav.subtabs {
+  font-size: 0.9rem;
+  margin: 1.5rem 0 0.75rem;
+}
+
+/* ── forms ───────────────────────────────────────────────────────────────── */
+
+form.match-form {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+  gap: 0.85rem 1rem;
+  margin: 0.5rem 0 0;
+}
+form.match-form.full { display: block; }
+.hidden { display: none !important; }
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+.field.span-2 { grid-column: span 2; }
+.field.span-3 { grid-column: span 3; }
+.field.span-all { grid-column: 1 / -1; }
+
+.field > label,
+.field > .label {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--muted);
+  letter-spacing: 0.01em;
+}
+.field .hint {
+  font-size: 0.75rem;
+  color: var(--muted);
+}
+.field input[type="text"],
+.field input[type="number"],
+.field input[type="date"],
+.field select,
+.field textarea {
+  width: 100%;
+  padding: 0.4rem 0.5rem;
+  font-family: inherit;
+  font-size: 0.9rem;
+  color: var(--fg);
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+}
+.field input:focus,
+.field select:focus,
+.field textarea:focus {
+  outline: 2px solid var(--accent);
+  outline-offset: -1px;
+  border-color: var(--accent);
+}
+.field textarea {
+  font-family: var(--mono);
+  font-size: 0.8rem;
+  resize: vertical;
+  min-height: 7rem;
+  line-height: 1.45;
+}
+.field.radio,
+.field.check {
+  flex-direction: column;
+  gap: 0.25rem;
+}
+.field.radio .opts,
+.field.check .opts {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+.field.radio label,
+.field.check label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  font-weight: normal;
+  color: var(--fg);
+  font-size: 0.85rem;
+  letter-spacing: 0;
+  cursor: pointer;
+}
+.field input[type="radio"],
+.field input[type="checkbox"] {
+  margin: 0;
+}
+
+.form-actions {
+  grid-column: 1 / -1;
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+  margin-top: 0.25rem;
+}
+button.run, button.primary {
+  font-family: inherit;
+  font-size: 0.95rem;
+  font-weight: 600;
+  padding: 0.5rem 1.1rem;
+  border: none;
+  border-radius: 4px;
+  background: var(--accent);
+  color: white;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+button.run:hover, button.primary:hover { background: var(--accent-d); }
+button.run:disabled, button.primary:disabled {
+  background: var(--muted);
+  cursor: not-allowed;
+  opacity: 0.7;
+}
+button.secondary {
+  font-family: inherit;
+  font-size: 0.85rem;
+  padding: 0.35rem 0.8rem;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: var(--bg);
+  color: var(--fg);
+  cursor: pointer;
+}
+button.secondary:hover { background: var(--panel); }
+
+/* ── results panel ───────────────────────────────────────────────────────── */
+
+#output { margin-top: 1.5rem; }
+
+.subpanel { min-height: 8rem; }
+
+.result-toolbar {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  margin-bottom: 0.6rem;
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+.result-toolbar .spacer { flex: 1; }
+.result-toolbar code {
+  background: var(--panel);
+  padding: 0.1em 0.4em;
+  border-radius: 3px;
+  font-size: 0.85em;
+}
+
+/* sortable, sticky-header table */
+#table-wrap {
+  max-height: 60vh;
+  overflow: auto;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+}
+table.results {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.82rem;
+  font-variant-numeric: tabular-nums;
+}
+table.results thead th {
+  position: sticky;
+  top: 0;
+  background: var(--panel);
+  z-index: 1;
+  text-align: left;
+  font-weight: 600;
+  padding: 0.45rem 0.6rem;
+  border-bottom: 2px solid var(--border);
+  white-space: nowrap;
+}
+table.results tbody td {
+  padding: 0.3rem 0.6rem;
+  border-bottom: 1px solid var(--border);
+  vertical-align: top;
+  white-space: nowrap;
+}
+table.results tbody tr:hover { background: var(--panel); }
+table.results .num { text-align: right; }
+
+pre.codeblock,
+#panel-sql pre,
+#panel-meta pre {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 0.75rem;
+  font-family: var(--mono);
+  font-size: 0.78rem;
+  line-height: 1.5;
+  overflow-x: auto;
+  margin: 0;
+}
+
+.pagination {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  margin-top: 0.6rem;
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+.pagination button {
+  font: inherit;
+  padding: 0.2rem 0.55rem;
+  border: 1px solid var(--border);
+  background: var(--bg);
+  border-radius: 3px;
+  cursor: pointer;
+}
+.pagination button:disabled { opacity: 0.4; cursor: not-allowed; }
+
+footer {
+  margin-top: 3rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--border);
+  font-size: 0.82rem;
+  color: var(--muted);
+}
+footer code {
+  background: var(--panel);
+  padding: 0.1em 0.4em;
+  border-radius: 3px;
+}


### PR DESCRIPTION
A **standalone, JavaScript-only Match app** at [`docs/match/`](https://github.com/CalCOFI/docs/tree/match-wasm-app/match) that mirrors the three retired Plumber-API bio↔env endpoints (`zooplankton_biomass`, `itis_ichthyodata`, `ichthyodata`) — implemented as a tabbed form whose **Run** button executes against the public CalCOFI release Parquet in DuckDB-WASM, **client-side**. No server, no credentials, no install, no R or Python.

Plus the cross-doc *"Run it from anywhere"* alignment promised in the plan: each chapter (Data Access, Helpers, API) now tells the same R / Python / shell / browser story with consistent framing and links to the new app.

## What's in here

| Path | What |
|---|---|
| `docs/match/index.html` | page shell, 5 tabs: **by name** (default), **by taxon**, **zoo biomass**, **custom (bio + env)**, **SQL shell**; pre-populated with the recurring Q1 2018 sardine-larva example |
| `docs/match/match.js`  | pure-JS port of [`calcofi4r/R/match.R`](https://github.com/CalCOFI/calcofi4r/blob/main/R/match.R) — same templates, same nested CTEs, same recursive WoRMS taxon walk |
| `docs/match/app.js`    | UI runtime: lazy [`@duckdb/duckdb-wasm@1.29.0`](https://www.npmjs.com/package/@duckdb/duckdb-wasm) from jsDelivr, paginated sortable table, Results / SQL / Metadata sub-tabs, Download CSV, Copy SQL, Download \`.sql\`, \`?version=\` deep-link |
| `docs/match/style.css` | light styling matching the cosmo book theme |
| `docs/_quarto.yml`     | \`match/\` added under \`project.resources\` so Quarto copies the app into \`_book/match/\` on render |
| `docs/data-access.qmd` | new **From your browser** section with a 15-line DuckDB-WASM boilerplate; new **Run it from anywhere** 4-row table; Reproducibility now names the Match app as a fourth equivalent source-of-truth |
| `docs/helpers.qmd`     | new **Run it from anywhere** section; widened the "copy-paste into any DuckDB client" enumeration |
| `docs/api.qmd`         | new \`.callout-tip\` pointing at the Match app + **Browser** column on the endpoint→replacement table with deep links to each tab |

## Verified

- **SQL fidelity** — \`match.js\` emits SQL **character-identical** to \`attr(cc_match_*(...), \"sql\")\` from R for all three wrappers (\`by name\`, \`by taxon\`, \`zoo biomass\`); \`diff\` is empty.
- **Browser end-to-end** — Playwright + Chromium against a local HTTP server: page loads, default form pre-populated, click **Run** → DuckDB-WASM cold-init from jsDelivr (~5 s) → GCS Parquet range-fetches + match query → **13 rows × 19 cols in 29.5 s**, matching the \`calcofi4r\` helpers, the [data-access](https://calcofi.io/docs/data-access.html) worked example, and the [int-app](https://app.calcofi.io/int) download bundle.
- **CORS** — applied an open \`GET\`/\`HEAD\` CORS config to \`gs://calcofi-db\` (same shape as the existing \`gs://calcofi-files-public\` config) so DuckDB-WASM in any browser can range-fetch the release Parquet without preflight failures.
- **Renders** — \`quarto render\` for the three modified chapters produces clean HTML.

Companion: [CalCOFI/calcofi4r#13](https://github.com/CalCOFI/calcofi4r/pull/13) (vignette browser bullet pointed at the new app).

🤖 Generated with [Claude Code](https://claude.com/claude-code)